### PR TITLE
Default create time to next hour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@
 
 # Go workspace file
 go.work
+
+test.db
+
+# stupid Macs
+DS_Store

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## Run locally
+`go run .`
+
+## Build
+`./build.sh`
+
 ## TODOs
 * location/maps
 * use cookies to remember invites? (ha passkeys?)

--- a/templates/aggro_create.tmpl
+++ b/templates/aggro_create.tmpl
@@ -20,12 +20,12 @@
         }
     </style>
     <script type="text/javascript">
-    (function(c,l,a,r,i,t,y){
-        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-    })(window, document, "clarity", "script", "nl9q05t0mc");
-</script>	
+        (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "nl9q05t0mc");
+    </script>	
 </head>
 <body>
     <div class="container">
@@ -39,6 +39,19 @@
                 <!-- consider https://github.com/williamtroup/Calendar.js/ -->
                 <input type="datetime-local" id="Start" name="Start" class="form-control">
 				<input type="hidden" id="TimeZone" name="TimeZone" >
+                <script type="text/javascript">
+                    function toLocalISOString(date) {
+                        const localDate = new Date(date - date.getTimezoneOffset() * 60000); //offset in milliseconds. Credit https://stackoverflow.com/questions/10830357/javascript-toisostring-ignores-timezone-offset
+
+                        // Round up to next hour, removing minutes, seconds, and milliseconds
+                        localDate.setMinutes(0, 0, 0);
+                        localDate.setHours(localDate.getHours() + 1);
+                        return localDate.toISOString().slice(0, -1);
+                    }
+                    window.addEventListener("load", () => {
+                        document.getElementById("Start").value = toLocalISOString(new Date());
+                    });
+                </script>
             </div>
             <input type="submit" class="btn btn-success" value="Let's Fucking GO!">
         </form>

--- a/templates/nice_create.tmpl
+++ b/templates/nice_create.tmpl
@@ -38,6 +38,19 @@
                 <label for="Start" class="form-label">When:</label>
                 <input type="datetime-local" id="Start" name="Start" class="form-control">
 				<input type="hidden" id="TimeZone" name="TimeZone" >
+                <script type="text/javascript">
+                    function toLocalISOString(date) {
+                        const localDate = new Date(date - date.getTimezoneOffset() * 60000); //offset in milliseconds. Credit https://stackoverflow.com/questions/10830357/javascript-toisostring-ignores-timezone-offset
+
+                        // Round up to next hour, removing minutes, seconds, and milliseconds
+                        localDate.setMinutes(0, 0, 0);
+                        localDate.setHours(localDate.getHours() + 1);
+                        return localDate.toISOString().slice(0, -1);
+                    }
+                    window.addEventListener("load", () => {
+                        document.getElementById("Start").value = toLocalISOString(new Date());
+                    });
+                </script>
             </div>
             <input type="submit" class="btn btn-success" value="Lets make some magic!">
         </form>


### PR DESCRIPTION
- Add build and local run commands to readme
- Add test.db and DS_Store to gitignore
- In create templates, default the event time to the current time rounded up to the next hour (removing minutes, seconds, milliseconds)